### PR TITLE
fix: 카테고리 버튼 클릭 시 같은 값 두 번 클릭하면 게시글 목록 사라지는 이슈 해결

### DIFF
--- a/ott/src/pages/Posts.jsx
+++ b/ott/src/pages/Posts.jsx
@@ -129,6 +129,9 @@ export default function Posts() {
 
   // 카테고리 변경 핸들러
   const handleCategoryChange = (newCategory) => {
+    // 같은 카테고리를 클릭한 경우 아무 동작도 하지 않음
+    if (category === newCategory) return;
+
     setCategory(newCategory);
     setSearchParams((prev) => {
       prev.set('category', newCategory);


### PR DESCRIPTION
fix: 카테고리 버튼 클릭 시 같은 값 두 번 클릭하면 게시글 목록 사라지는 이슈 해결