### PR TITLE
feat: 401 에러에 대한 로그인 모달 적용

### DIFF
--- a/ott/src/App.jsx
+++ b/ott/src/App.jsx
@@ -1,55 +1,48 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import RootLayout from './components/layout/RootLayout';
-import PrivateRoute from './components/PrivateRoute';
+import { ModalProvider } from '@/hooks/useGlobalModal'; // 추가!
 import OAuth2RedirectHandler from '@/pages/OAuth2RedirectHandler';
-import ScrollToTop from './components/common/ScrollToTop';
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import ImageGenerationLoader from './components/common/ImageGenerationLoader';
+import LoginModal from './components/common/LoginModal'; // 추가!
+import ScrollToTop from './components/common/ScrollToTop';
+import RootLayout from './components/layout/RootLayout';
 
 // 페이지 컴포넌트들
+import AiGenerationResult from './pages/AiGenerationResult';
+import DeskAI from './pages/DeskAI';
 import Home from './pages/Home';
 import Login from './pages/Login';
+import MyPage from './pages/MyPage';
 import NotFound from './pages/NotFound';
-import DeskAI from './pages/DeskAI';
-import AiGenerationResult from './pages/AiGenerationResult';
+import PostDetail from './pages/PostDetail';
 import PostEditor from './pages/PostEditor';
 import Posts from './pages/Posts';
-import PostDetail from './pages/PostDetail';
-import MyPage from './pages/MyPage';
 import ProfileEdit from './pages/ProfileEdit';
 
 const App = () => {
   return (
-    <Router>
-      <ImageGenerationLoader />
-      <ScrollToTop />
-      <Routes>
-        {/* RootLayout을 사용하는 라우트 */}
-        <Route element={<RootLayout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/desk" element={<DeskAI />} />
-          <Route path="/posts" element={<Posts />} />
-          <Route path="/mypage" element={<MyPage />} />
-          {/* 보호된 라우트들도 여기에 추가 */}
-          {/* <Route
-            path="/mypage"
-            element={
-              <PrivateRoute>
-                <MyPage />
-              </PrivateRoute>
-            }
-          /> */}
-        </Route>
-
-        {/* RootLayout을 사용하지 않는 라우트 */}
-        <Route path="/login" element={<Login />} />
-        <Route path="/oauth-success" element={<OAuth2RedirectHandler />} />
-        <Route path="/post-editor" element={<PostEditor />} />
-        <Route path="/ai-images/:imageId" element={<AiGenerationResult />} />
-        <Route path="/posts/:postId" element={<PostDetail />} />
-        <Route path="/profile-edit" element={<ProfileEdit />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Router>
+    <ModalProvider>
+      <Router>
+        <ImageGenerationLoader />
+        <ScrollToTop />
+        <LoginModal /> {/* 항상 모달이 뜰 수 있게 라우터/라우트 밖에 둡니다! */}
+        <Routes>
+          <Route element={<RootLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/desk" element={<DeskAI />} />
+            <Route path="/posts" element={<Posts />} />
+            <Route path="/mypage" element={<MyPage />} />
+            {/* 보호된 라우트들도 여기에 추가 */}
+          </Route>
+          <Route path="/login" element={<Login />} />
+          <Route path="/oauth-success" element={<OAuth2RedirectHandler />} />
+          <Route path="/post-editor" element={<PostEditor />} />
+          <Route path="/ai-images/:imageId" element={<AiGenerationResult />} />
+          <Route path="/posts/:postId" element={<PostDetail />} />
+          <Route path="/profile-edit" element={<ProfileEdit />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Router>
+    </ModalProvider>
   );
 };
 

--- a/ott/src/api/axios.js
+++ b/ott/src/api/axios.js
@@ -1,11 +1,12 @@
-import axios from 'axios';
 import { getConfig } from '@/config/index';
+import { triggerGlobalModal } from '@/hooks/globalModalController';
+import axios from 'axios';
 
 const { BASE_URL } = getConfig();
 
 export const axiosInstance = axios.create({
   baseURL: BASE_URL,
-  timeout: 5000,
+  timeout: 0,
 });
 
 // 요청 인터셉터
@@ -17,10 +18,7 @@ axiosInstance.interceptors.request.use(
     }
     return config;
   },
-  (error) => {
-    console.log('error 인터셉트', error);
-    return Promise.reject(error);
-  },
+  (error) => Promise.reject(error),
 );
 
 // 응답 인터셉터
@@ -28,41 +26,23 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-
-    // 토큰이 만료되었고, 재시도하지 않았던 요청인 경우
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-
-      try {
-        // 토큰 재발급
-        const response = await axios.post(
-          `${BASE_URL}/auth/token/refresh`,
-          {},
-          {
-            withCredentials: true,
-          },
-        );
-        if (response.data.status === 200 && response.data.data.accessToken) {
-          const { accessToken } = response.data.data;
-          localStorage.setItem('accessToken', accessToken);
-          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-          return axiosInstance(originalRequest);
-        } else {
-          // 리프레시 토큰도 만료된 경우
-          localStorage.removeItem('accessToken');
-          // 로그인 페이지로 리다이렉트
-          window.location.href = '/login';
-          return Promise.reject(error);
-        }
-      } catch (error) {
-        // 리프레시 토큰도 만료된 경우
-        localStorage.removeItem('accessToken');
-        // 로그인 페이지로 리다이렉트
-        window.location.href = '/login';
-        return Promise.reject(error);
-      }
+      // 리프레시 토큰 갱신 시도 등 추가 가능
+      // ...여기선 생략, 바로 로그인 필요 모달
+      triggerGlobalModal({
+        open: true,
+        message: '로그인이 필요합니다. 로그인 후 다시 시도해주세요.',
+        leftButtonText: '나중에',
+        rightButtonText: '로그인하기',
+        onLeftClick: () => triggerGlobalModal({ open: false }),
+        onRightClick: () => {
+          triggerGlobalModal({ open: false });
+          window.location.href = '/login'; // useNavigate 쓸 수 없는 위치이므로
+        },
+      });
+      return Promise.reject(error);
     }
-
     return Promise.reject(error);
   },
 );

--- a/ott/src/components/common/LoginModal.jsx
+++ b/ott/src/components/common/LoginModal.jsx
@@ -1,38 +1,25 @@
-import React, { useEffect, useState } from 'react';
+import SimpleModal from '@/components/common/SimpleModal';
+import useGlobalModal from '@/hooks/useGlobalModal';
 import { useNavigate } from 'react-router-dom';
-import SimpleModal from './SimpleModal';
 
 const LoginModal = () => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [message, setMessage] = useState('');
-  const [redirectUrl, setRedirectUrl] = useState('');
+  const { modal, setModal } = useGlobalModal();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const handleLoginRequired = (event) => {
-      setMessage(event.detail.message);
-      setRedirectUrl(event.detail.redirectUrl);
-      setIsOpen(true);
-    };
+  if (!modal.open) return null;
 
-    window.addEventListener('loginRequired', handleLoginRequired);
-    return () => window.removeEventListener('loginRequired', handleLoginRequired);
-  }, []);
-
-  const handleClose = () => {
-    setIsOpen(false);
-    // 로그인 페이지로 이동하면서 현재 페이지 URL을 state로 전달
-    navigate('/login', { state: { from: redirectUrl } });
-  };
-
+  // 로그인 필요 모달만 보여주는 용도로 사용!
   return (
     <SimpleModal
-      open={isOpen}
-      message={message}
-      onClose={handleClose}
-      showCancel={true}
-      confirmText="로그인하기"
-      cancelText="나중에"
+      open={modal.open}
+      message="로그인 후 다시 시도해주세요."
+      rightButtonText="로그인하기"
+      onLeftClick={() => setModal({ ...modal, open: false })}
+      onRightClick={() => {
+        setModal({ ...modal, open: false });
+        navigate('/login');
+      }}
+      onClose={() => setModal({ ...modal, open: false })}
     />
   );
 };

--- a/ott/src/components/common/SimpleModal.jsx
+++ b/ott/src/components/common/SimpleModal.jsx
@@ -1,51 +1,32 @@
-import React from 'react';
-
-const SimpleModal = ({
-  open,
-  title,
-  message,
-  onClose,
-  onConfirm,
-  leftButtonText = '확인',
-  rightButtonText,
-  onLeftClick,
-  onRightClick,
-}) => {
+const SimpleModal = ({ open, title, message, onClose, rightButtonText, onRightClick }) => {
   if (!open) return null;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-sm w-full mx-4">
+      <div className="bg-white rounded-lg p-6 max-w-sm w-full mx-4 relative">
+        {/* X 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-700 text-xl"
+          aria-label="닫기"
+        >
+          ×
+        </button>
         {title && (
           <div className="mb-4 pb-2">
-            <h2 className="text-lg font-bold text-center">{title}</h2>
+            <h2 className="text-base font-bold text-center text-[#1A2238]">{title}</h2>
           </div>
         )}
-        <p className="text-center whitespace-pre-line mb-6" style={{ whiteSpace: 'pre-line' }}>
+        <p className="text-center whitespace-pre-line mb-6 text-lg font-semibold text-[#232946]">
           {message}
         </p>
-        <div className="flex justify-center gap-3">
-          {rightButtonText ? (
-            <>
-              <button
-                onClick={onLeftClick || onClose}
-                className="flex-1 px-6 py-2 bg-gray-200 text-black rounded-lg font-semibold"
-              >
-                {leftButtonText}
-              </button>
-              <button
-                onClick={onRightClick || onConfirm || onClose}
-                className="flex-1 px-6 py-2 bg-blue-500 text-white rounded-lg font-semibold"
-              >
-                {rightButtonText}
-              </button>
-            </>
-          ) : (
+        <div className="flex justify-center">
+          {rightButtonText && (
             <button
-              onClick={onConfirm || onClose}
-              className="px-6 py-2 bg-gray-500 text-white rounded-lg"
+              onClick={onRightClick || onClose}
+              className="px-4 py-2 rounded-lg bg-[#232946] text-white font-semibold text-sm hover:bg-[#1A2238] transition"
             >
-              {leftButtonText}
+              {rightButtonText}
             </button>
           )}
         </div>

--- a/ott/src/hooks/globalModalController.js
+++ b/ott/src/hooks/globalModalController.js
@@ -1,0 +1,8 @@
+let setModalFn = null;
+
+export const setGlobalModal = (setter) => {
+  setModalFn = setter;
+};
+export const triggerGlobalModal = (modalProps) => {
+  setModalFn && setModalFn(modalProps);
+};

--- a/ott/src/hooks/useDeskAICheck.js
+++ b/ott/src/hooks/useDeskAICheck.js
@@ -24,13 +24,7 @@ const useDeskAICheck = () => {
     } catch (err) {
       console.log('checkDeskAIAvailability error', err);
 
-      if (err.response?.status === 401) {
-        setModal({
-          open: true,
-          message: '로그인이 필요한 기능입니다.\n로그인 후 다시 시도해주세요.',
-          onConfirm: null,
-        });
-      } else if (err.response?.status === 403) {
+      if (err.response?.status === 403) {
         setModal({
           open: true,
           message: `오늘 이미지 생성 횟수(1회)를 모두 소진했습니다.\n내일 다시 시도해주세요.`,

--- a/ott/src/hooks/useGlobalModal.jsx
+++ b/ott/src/hooks/useGlobalModal.jsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { setGlobalModal } from './globalModalController';
+
+const ModalContext = createContext();
+
+export const ModalProvider = ({ children }) => {
+  const [modal, setModal] = useState({
+    open: false,
+    message: '',
+    leftButtonText: '나중에',
+    rightButtonText: '로그인하기',
+    onLeftClick: null,
+    onRightClick: null,
+  });
+
+  useEffect(() => {
+    setGlobalModal(setModal);
+  }, []);
+
+  return <ModalContext.Provider value={{ modal, setModal }}>{children}</ModalContext.Provider>;
+};
+
+const useGlobalModal = () => useContext(ModalContext);
+export default useGlobalModal;

--- a/ott/src/pages/Home.jsx
+++ b/ott/src/pages/Home.jsx
@@ -76,6 +76,10 @@ const Home = () => {
         ),
       }));
     } catch (err) {
+      if (err.response?.status === 401) {
+        // 아무것도 하지 않음 (전역 모달에서 처리됨)
+        return;
+      }
       setToast('전송에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setTimeout(() => setToast(''), 1500);

--- a/ott/src/pages/PostDetail.jsx
+++ b/ott/src/pages/PostDetail.jsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import TopBar from '@/components/common/TopBar';
-import axiosInstance from '../api/axios';
-import axios from 'axios';
-import SimpleModal from '@/components/common/SimpleModal';
-import CommentBottomSheet from '@/components/common/CommentBottomSheet';
-import Toast from '@/components/common/Toast';
 import { addLike, removeLike } from '@/api/likes';
 import { addScrap, removeScrap } from '@/api/scraps';
+import CommentBottomSheet from '@/components/common/CommentBottomSheet';
+import SimpleModal from '@/components/common/SimpleModal';
+import Toast from '@/components/common/Toast';
+import TopBar from '@/components/common/TopBar';
 import { getConfig } from '@/config/index';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axiosInstance from '../api/axios';
 
 const { BASE_URL } = getConfig();
 const axiosBaseInstance = axios.create({
@@ -144,7 +144,8 @@ export default function PostDetail() {
         liked: !prev.liked,
         likeCount: prev.liked ? prev.likeCount - 1 : prev.likeCount + 1,
       }));
-    } catch {
+    } catch (err) {
+      if (err.response?.status === 401) return;
       setToast('전송에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setTimeout(() => setToast(''), 1500);
@@ -165,7 +166,8 @@ export default function PostDetail() {
         ...prev,
         scrapped: !prev.scrapped,
       }));
-    } catch {
+    } catch (err) {
+      if (err.response?.status === 401) return;
       setToast('전송에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setTimeout(() => setToast(''), 1500);
@@ -174,7 +176,13 @@ export default function PostDetail() {
 
   // 댓글 등록 함수 예시
   const handleCommentSubmit = () => {
-    if (commentInput.trim().length === 0) return;
+    try {
+      if (commentInput.trim().length === 0) return;
+    } catch (err) {
+      if (err.response?.status === 401) return;
+      setToast('댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+
     // 실제 등록 로직 추가
     // setComments([...comments, ...]);
     setCommentInput('');


### PR DESCRIPTION
## ✏️ PR 내용
### feat: 401 에러에 대한 로그인 모달 적용

### 설명
- 비로그인 사용자가 좋아요, 스크랩, 댓글 등과 같은 인증이 필요한 기능을 실행할 때 경고 메시지 없이 로그인 페이지로 이동한다.
- 페이지 이동의 의도를 사용자에게 명확하게 전달하기 위해 401 에러가 발생하면 로그인 경고 모달 창을 띄운다.
- 로그인 원할 시 "로그인하기" 버튼을 클릭하면 로그인 페이지로 이동한다.
- 로그인을 원하지 않을 시 "x" 버튼을 클릭하면 모달 창이 닫힌다.

### 테스트 방법
1. vscode에서 'yarn dev'로 서버 실행
2. IntelliJ에서 'cntl + F10'으로 서버 실행
3. 비로그인 상태에서 좋아요, 스크랩, 댓글 작성, 데스크 생성 버튼 클릭

### 화면 캡처 / 녹화
<img width="375" alt="image" src="https://github.com/user-attachments/assets/9bad33a8-af6b-46b6-bb6f-3be59191af48" />

